### PR TITLE
forbids filling of tanks with rotten liquids

### DIFF
--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6231,7 +6231,7 @@ bool vehicle_part::can_reload( const itype_id &obj ) const
 
 bool vehicle_part::fill_with( item &liquid, long qty )
 {
-    if( liquid.active || liquid.rotten ) {
+    if( liquid.active || liquid.rotten() ) {
         // cannot refill using active liquids (those that rot) due to #18570
         return false;
     }

--- a/src/vehicle.cpp
+++ b/src/vehicle.cpp
@@ -6231,7 +6231,7 @@ bool vehicle_part::can_reload( const itype_id &obj ) const
 
 bool vehicle_part::fill_with( item &liquid, long qty )
 {
-    if( liquid.active ) {
+    if( liquid.active || liquid.rotten ) {
         // cannot refill using active liquids (those that rot) due to #18570
         return false;
     }


### PR DESCRIPTION
fixes #20844
the current check for disallowing rottable liquids only checks for the active state. Once a liquid is rotten it turns inactive and is suddenly allowed to be filled in the tank. I added a secondary check for the rotten state.